### PR TITLE
change URL from wiki to kb.segger.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ RTT
 SEGGER RTT Sources
 
 https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer  
-https://wiki.segger.com/RTT
+https://kb.segger.com/RTT
 
 ## Included files
 


### PR DESCRIPTION
The wiki has been renamed to knowledge base